### PR TITLE
oi-371 oi-375 ready for code review

### DIFF
--- a/controller/exchange/dataexchanger.cpp
+++ b/controller/exchange/dataexchanger.cpp
@@ -375,6 +375,16 @@ void DataExchanger::importFeatures(const bool &success){
         }
     }
 
+    //get the specified coordinate system by its defined name from exchange parameters and set this one true
+    //so destination system from import nominals is active system and all nominal values will be shown directly
+    QList<QPointer<CoordinateSystem> >coordSystemList = this->currentJob->getCoordinateSystemsList();
+    foreach (QPointer<CoordinateSystem> cs, coordSystemList) {
+        if(cs->getFeatureName().compare(this->exchangeParams.nominalSystem) == 0){
+            this->currentJob->getActiveCoordinateSystem()->setActiveCoordinateSystemState(false);
+            cs->setActiveCoordinateSystemState(true);
+        }
+    }
+
     //delete exchange instance because it is not necessary anymore
     delete this->exchange;
 

--- a/ui/mainwindow.cpp
+++ b/ui/mainwindow.cpp
@@ -76,9 +76,9 @@ void MainWindow::importNominalsFinished(const bool &success){
     }else{
         emit this->log("Nominals not imported successfully", eErrorMessage, eMessageBoxMessage);
     }
-
+    this->resizeTableView();
     this->loadingDialog.close();
-
+    this->ui->comboBox_activeCoordSystem->setCurrentText("PART");
 }
 
 /*!

--- a/ui/mainwindow.cpp
+++ b/ui/mainwindow.cpp
@@ -78,7 +78,6 @@ void MainWindow::importNominalsFinished(const bool &success){
     }
     this->resizeTableView();
     this->loadingDialog.close();
-    this->ui->comboBox_activeCoordSystem->setCurrentText("PART");
 }
 
 /*!


### PR DESCRIPTION
after import the active coordinate system is set to the selected system from exchange parameters. Because of that all imported nominal values are shown directly in the view. Additionally the column and row size is auto scaled to the biggest text of features.