### PR TITLE
oi-165 Ankerfunktion

### DIFF
--- a/ui/mainwindow.cpp
+++ b/ui/mainwindow.cpp
@@ -2049,6 +2049,7 @@ void MainWindow::connectController(){
     QObject::connect(&this->control, &Controller::sensorActionFinished, this, &MainWindow::sensorActionFinished, Qt::AutoConnection);
     QObject::connect(&this->control, &Controller::measurementCompleted, this, &MainWindow::measurementCompleted, Qt::AutoConnection);
     QObject::connect(&this->control, &Controller::measurementDone, this, &MainWindow::measurementDone, Qt::AutoConnection);
+    QObject::connect(&this->control, &Controller::measurementDone, this, &MainWindow::goToNextFeature, Qt::AutoConnection);
     QObject::connect(&this->control, &Controller::showMessageBox, this, &MainWindow::showMessageBox, Qt::AutoConnection);
     QObject::connect(&this->control, &Controller::showStatusMessage, this, &MainWindow::showStatusMessage, Qt::AutoConnection);
     QObject::connect(&this->control, &Controller::availableGroupsChanged, this, &MainWindow::availableGroupsChanged, Qt::AutoConnection);
@@ -2689,6 +2690,20 @@ void MainWindow::loadDefaultBundlePlugIn(int bundleID)
     //load template
     emit this->loadBundleTemplate(bundleID, bundleTemplate);
     this->bundleSelectionChanged();
+}
+
+/*!
+ * \brief MainWindow::goToNextFeature
+ * Jumping to the next feature in the feature list after an successful measurement
+ */
+void MainWindow::goToNextFeature(bool success)
+{
+    if(success){
+        if(this->ui->actiongo_to_next_feature->isChecked()){
+            this->ui->tableView_features->selectRow(this->ui->tableView_features->currentIndex().row() + 1);
+        }
+    }
+    return;
 }
 
 /*!

--- a/ui/mainwindow.h
+++ b/ui/mainwindow.h
@@ -339,6 +339,9 @@ private:
     //load default bundle plugin
     void loadDefaultBundlePlugIn(int bundleID);
 
+    //go automatically to next feature
+    void goToNextFeature(bool success);
+
     //############################
     //OpenIndy dialogs and widgets
     //############################

--- a/ui/mainwindow.ui
+++ b/ui/mainwindow.ui
@@ -483,6 +483,7 @@ background-position: center center;</string>
      <string>Settings</string>
     </property>
     <addaction name="actionView_settings"/>
+    <addaction name="actiongo_to_next_feature"/>
    </widget>
    <widget class="QMenu" name="menuTools">
     <property name="title">
@@ -1283,6 +1284,23 @@ color: rgb(255, 255, 255);
    </property>
    <property name="text">
     <string>export</string>
+   </property>
+  </action>
+  <action name="actiongo_to_next_feature">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="checked">
+    <bool>false</bool>
+   </property>
+   <property name="text">
+    <string>go to next feature</string>
+   </property>
+   <property name="toolTip">
+    <string>jump to next feature in list after successful measurement</string>
+   </property>
+   <property name="statusTip">
+    <string>measurement</string>
    </property>
   </action>
  </widget>


### PR DESCRIPTION
added checkable settings in settings menu to activate and deactivate "jump to next feature after measurement" functionally. 
Currently only jumping to next feature after measurement was sucesscul. If not successful, the same old feature will stay selected